### PR TITLE
The permutations package is called `permutations`, not `permutation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ including:
 -   create a factor variable from the quantiles of a continuous variable
     (`quantcut`),
 -   enumerate permutations and combinations (`combinations`,
-    `permutation`),
+    `permutations`),
 -   calculate and convert between fold-change and log-ratio
     (`foldchange`, `logratio2foldchange`, `foldchange2logratio`),
 -   calculate probabilities and generate random numbers from Dirichlet


### PR DESCRIPTION
This was a typo that cost me some time when learning R through an edX course - wanted to fix it so that others don't get tripped up by it too