### PR TITLE
Extend Unicode support in ASCIIfy()

### DIFF
--- a/R/ASCIIfy.R
+++ b/R/ASCIIfy.R
@@ -58,12 +58,12 @@ ASCIIfy <- function(x, bytes = 2, fallback = "?") {
       } else {
         ascii <- fallback
         warning(char, " could not be converted to 1 byte")
-      }
-    } else if (length(raw) == 2 && bytes == 2) { # UTF-8 to \u0000
+      } # UTF-8 to \u0000
+    } else if (nchar(format.hexmode(utf8ToInt(char))) <= 4 && bytes == 2) {
       ascii <- paste0("\\u", format.hexmode(utf8ToInt(char), width = 4))
     } else {
       ascii <- fallback
-      warning(char, " could not be converted to ", bytes, " byte")
+      warning(char, " could not be converted to ", bytes, " bytes")
     }
     return(ascii)
   }

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,3 +1,8 @@
+gtools  3.9.6 - development
+---------------------------
+
+- improve `ASCIIfy()` so it handles a wider range of Unicode characters.
+
 gtools  3.9.5 - 2023-11-20
 --------------------------
 


### PR DESCRIPTION
Hi Ben,

The only thing more fun than drawing ASCII art is drawing UTF-8 art :)

Today, I wanted to ASCIIfy the └  character and was surprised that the ASCIIfy() function was choking on it. After a quick Heimlich maneuver, I modified a line in the code that allows it to convert a wider range of Unicode characters, including the highly useful └ character.

Reproducible example:

```
# Current gtools
source("https://raw.githubusercontent.com/r-gregmisc/gtools/bc5d659/R/ASCIIfy.R")
ASCIIfy("└")

# This pull request
source("https://raw.githubusercontent.com/arni-magnusson/gtools/refs/heads/master/R/ASCIIfy.R")
ASCIIfy("└")
```